### PR TITLE
bringing in cf changes

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,9 +20,6 @@ mkdir -p $MACOS_DIR
 # (and `pythonw`) will always be the one installed via the `python` package.
 ln -s ../../../bin/python $MACOS_DIR/python
 
-install_name_tool -change "@loader_path/../lib/libpython${PY_VER}.dylib" \
-    "$PREFIX/lib/libpython${PY_VER}.dylib" $MACOS_DIR/python
-
 PYAPP=$PREFIX/bin/python.app
 cat <<EOF >$PYAPP
 #!/bin/bash

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,9 +18,6 @@ requirements:
 test:
   files:
     - t.py
-  commands:
-    - python.app -V
-    - pythonw -V
 
 about:
   home: https://www.python.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 3
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not osx]
 
 requirements:

--- a/recipe/post-link.sh
+++ b/recipe/post-link.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cp -r "$PREFIX/pythonapp" "$PREFIX/python.app"
+cp -R "$PREFIX/pythonapp" "$PREFIX/python.app"
 rm -rf "$PREFIX/pythonapp"
 
 cd "$PREFIX/python.app/Contents"


### PR DESCRIPTION
python.app 3 b1

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-5542

### Explanation of changes:

- On the previous build, the path pythonapp/Contents/MacOS/python would be a copy of the python executable from build time, instead of a symlink to `../../../bin/python`. See https://anaconda.atlassian.net/browse/PKG-5542 for details.
- The changes from the conda-forge recipe have been brought in.